### PR TITLE
Add HF integration

### DIFF
--- a/src/doubletake/experiment_modules/doubletake_model.py
+++ b/src/doubletake/experiment_modules/doubletake_model.py
@@ -31,10 +31,12 @@ from doubletake.utils.geometry_utils import NormalGenerator
 from doubletake.utils.metrics_utils import compute_depth_metrics
 from doubletake.utils.visualization_utils import colormap_image
 
+from huggingface_hub import PyTorchModelHubMixin
+
 logger = logging.getLogger(__name__)
 
 
-class DepthModelCVHint(pl.LightningModule):
+class DepthModelCVHint(pl.LightningModule, PyTorchModelHubMixin, repo_url="https://github.com/nianticlabs/doubletake", pipeline_tag="image-to-3d", license="other"):
     """Class for DoubleTake depth estimators.
 
     This class handles training and inference for DoubleTake models.

--- a/src/doubletake/experiment_modules/sr_depth_model.py
+++ b/src/doubletake/experiment_modules/sr_depth_model.py
@@ -32,10 +32,12 @@ from doubletake.utils.geometry_utils import NormalGenerator
 from doubletake.utils.metrics_utils import compute_depth_metrics
 from doubletake.utils.visualization_utils import colormap_image
 
+from huggingface_hub import PyTorchModelHubMixin
+
 logger = logging.getLogger(__name__)
 
 
-class DepthModel(pl.LightningModule):
+class DepthModel(pl.LightningModule, PyTorchModelHubMixin, repo_url="https://github.com/nianticlabs/doubletake", pipeline_tag="image-to-3d", license="other"):
     """Class for SimpleRecon depth estimators.
 
     This class handles training and inference for SimpleRecon models.


### PR DESCRIPTION
Hi @mohammed-amr and team,

Thanks for this nice work! I wrote a quick PoC to showcase that you can easily have integration with the 🤗 hub so that you can 

* automatically load the model using `from_pretrained` (and push it using `push_to_hub`)
* track download numbers for your models (similar to models in the Transformers library)
* have nice model cards on a per-model basis along with tags (so that people find them when filtering https://hf.co/models) 
* perhaps most importantly, leverage `safetensors` for the weights in favor of pickle. 

Also, this greatly improves the discoverability of your model (as it's currently hosted on Google Storage which is hard to find).

It leverages the [PyTorchModelHubMixin](https://huggingface.co/docs/huggingface_hub/package_reference/mixins#huggingface_hub.PyTorchModelHubMixin) class which allows to inherits these methods.

Usage is as follows:

```python
from doubletake.experiment_modules.doubletake_model import DepthModelCVHint

# instantiate model
model = DepthModelCVHint(...)

# equip model with weights
model.load_state_dict(...)

# push to hub
model.push_to_hub("your-hf-org-or-username/depth-model-cv-hint")

# reload
model = DepthModelCVHint.from_pretrained("your-hf-org-or-username/depth-model-cv-hint")
```

This means people don't need to manually download a checkpoint first in their local environment, it just loads automatically from the hub. 

Would you be interested in this integration?

Kind regards,

Niels

## Note

Please don't merge this PR before pushing the model to the hub :)